### PR TITLE
fix: Update README to support example application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Architecture Center Samples
 
-This repo contains Terraform samples for [Cloud Architecture
+This repo contains supporting code artifacts for [Cloud Architecture
 Center](https://cloud.google.com/architecture/) references.
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Architecture Center Samples
 
-Terraform samples for [Cloud Architecture
-Center](https://cloud.google.com/architecture/)
+This repo contains Terraform samples for [Cloud Architecture
+Center](https://cloud.google.com/architecture/) references.
 
+> [!NOTE]
+> The code in this repo is not intended for production use.
 
 # Running samples
 

--- a/gen-ai-rag-vertex-ai-vector-search/README.md
+++ b/gen-ai-rag-vertex-ai-vector-search/README.md
@@ -20,10 +20,7 @@ Code](https://github.com/GoogleCloudPlatform/devrel-demos/tree/main/ai-ml/rag-ar
 > [!NOTE]
 > The App Source Code was produced for a Google Cloud Next demo and is unmaintained.
 
-We suggest manually changing the deployed infrastructure to try this example
-application (e.g. building the container images and editing the deployed
-service in the Google Cloud console to use the new container image, add
-environment variables, etc).
+We suggest deploying the terraform in this folder, then manually updating the deployment as described in the [sample application README](https://github.com/GoogleCloudPlatform/devrel-demos/tree/main/ai-ml/rag-architectures#steps) (i.e. building the container images and editing the deployed service in the Google Cloud console to use the new container image, add environment variables, etc).
 
 ## Comments within sample
 

--- a/gen-ai-rag-vertex-ai-vector-search/README.md
+++ b/gen-ai-rag-vertex-ai-vector-search/README.md
@@ -13,11 +13,17 @@ To try this sample:
 
 This will deploy the supporting infrastructure for the pattern.
 
-As an example application, follow the instructions in the [RAG Architectures - App Source Code](https://github.com/GoogleCloudPlatform/devrel-demos/tree/main/ai-ml/rag-architectures).
+If you want to install a functional example application, follow the
+instructions in the [RAG Architectures - App Source
+Code](https://github.com/GoogleCloudPlatform/devrel-demos/tree/main/ai-ml/rag-architectures).
 
 > [!NOTE]
 > The App Source Code was produced for a Google Cloud Next demo and is unmaintained.
-> We suggest manually changing the deployed infrastructure to try this example application.
+
+We suggest manually changing the deployed infrastructure to try this example
+application (e.g. building the container images and editing the deployed
+service in the Google Cloud console to use the new container image, add
+environment variables, etc).
 
 ## Comments within sample
 

--- a/gen-ai-rag-vertex-ai-vector-search/README.md
+++ b/gen-ai-rag-vertex-ai-vector-search/README.md
@@ -19,7 +19,6 @@ As an example application, follow the instructions in the [RAG Architectures - A
 > The App Source Code was produced for a Google Cloud Next demo and is unmaintained.
 > We suggest manually changing the deployed infrastructure to try this example application.
 
-
 ## Comments within sample
 
 This sample uses the following comment scheme:

--- a/gen-ai-rag-vertex-ai-vector-search/README.md
+++ b/gen-ai-rag-vertex-ai-vector-search/README.md
@@ -11,7 +11,7 @@ To try this sample:
   1. [Enable the required APIs](https://console.cloud.google.com/flows/enableapi?apiid=run.googleapis.com,pubsub.googleapis.com,aiplatform.googleapis.com,iam.googleapis.com,storage.googleapis.com,cloudfunctions.googleapis.com,eventarc.googleapis.com,cloudbuild.googleapis.com).
   1. Follow the [setup instructions](/README.md#setup) to deploy the sample.
 
-This will deploy the base architecture, but the applications will not be functional.
+This will deploy the supporting infrastructure for the pattern.
 
 As an example application, follow the instructions in the [RAG Architectures - App Source Code](https://github.com/GoogleCloudPlatform/devrel-demos/tree/main/ai-ml/rag-architectures).
 

--- a/gen-ai-rag-vertex-ai-vector-search/README.md
+++ b/gen-ai-rag-vertex-ai-vector-search/README.md
@@ -17,6 +17,7 @@ As an example application, follow the instructions in the [RAG Architectures - A
 
 > [!NOTE]
 > The App Source Code was produced for a Google Cloud Next demo and is unmaintained.
+> We suggest manually changing the deployed infrastructure to try this example application.
 
 
 ## Comments within sample
@@ -28,9 +29,7 @@ This sample uses the following comment scheme:
 diagram](https://cloud.google.com/architecture/gen-ai-rag-vertex-ai-vector-search#architecture).
 
 `Edit Me:`
-: Places to make changes to adapt the sample Terraform to support the sample
-application.
-
+: Places to make changes to adapt the sample Terraform to customize the deployment.
 
 `Design Considerations:`
 : configurations mapping to recommendations in the [design
@@ -39,4 +38,3 @@ considerations](https://cloud.google.com/architecture/gen-ai-rag-vertex-ai-vecto
 `Note:`
 : Changes or modifications that should be considered when adjusting the sample
 to deploy in production.
-

--- a/gen-ai-rag-vertex-ai-vector-search/README.md
+++ b/gen-ai-rag-vertex-ai-vector-search/README.md
@@ -9,8 +9,14 @@ Center](https://cloud.google.com/architecture/).
 To try this sample:
 
   1. [Enable the required APIs](https://console.cloud.google.com/flows/enableapi?apiid=run.googleapis.com,pubsub.googleapis.com,aiplatform.googleapis.com,iam.googleapis.com,storage.googleapis.com,cloudfunctions.googleapis.com,eventarc.googleapis.com,cloudbuild.googleapis.com).
-  1. Follow the [setup instructions](/README.md#setup).
-  1. Make changes to the sample, as indicated by `Note: ` comments.
+  1. Follow the [setup instructions](/README.md#setup) to deploy the sample.
+
+This will deploy the base architecture, but the applications will not be functional.
+
+As an example application, follow the instructions in the [RAG Architectures - App Source Code](https://github.com/GoogleCloudPlatform/devrel-demos/tree/main/ai-ml/rag-architectures).
+
+> [!NOTE]
+> The App Source Code was produced for a Google Cloud Next demo and is unmaintained.
 
 
 ## Comments within sample
@@ -20,6 +26,11 @@ This sample uses the following comment scheme:
 `###`
 : Major functional sections, mapping to the [architecture
 diagram](https://cloud.google.com/architecture/gen-ai-rag-vertex-ai-vector-search#architecture).
+
+`Edit Me:`
+: Places to make changes to adapt the sample Terraform to support the sample
+application.
+
 
 `Design Considerations:`
 : configurations mapping to recommendations in the [design

--- a/gen-ai-rag-vertex-ai-vector-search/ingestion.tf
+++ b/gen-ai-rag-vertex-ai-vector-search/ingestion.tf
@@ -59,6 +59,8 @@ resource "google_pubsub_topic_iam_member" "pubsub" {
 data "archive_file" "default" {
   type        = "zip"
   output_path = "/tmp/function-source.zip"
+
+  # Edit Me: Replace with a path to the customized "ingestion" function code
   source_dir  = "function-source/"
 }
 
@@ -88,7 +90,7 @@ resource "google_cloudfunctions2_function" "default" {
     entry_point = "process_data"
 
     source {
-      # From uploaded archive of local code folder
+      # Sample function from uploaded archive of local code folder
       storage_source {
         bucket = google_storage_bucket.default.name
         object = google_storage_bucket_object.default.name

--- a/gen-ai-rag-vertex-ai-vector-search/ingestion.tf
+++ b/gen-ai-rag-vertex-ai-vector-search/ingestion.tf
@@ -86,6 +86,7 @@ resource "google_cloudfunctions2_function" "default" {
   description = "Function to process Cloud Storage events"
 
   build_config {
+    # Note: Adjust based on the language/version of the ingestion app.
     runtime     = "python312"
     entry_point = "process_data"
 

--- a/gen-ai-rag-vertex-ai-vector-search/ingestion.tf
+++ b/gen-ai-rag-vertex-ai-vector-search/ingestion.tf
@@ -61,7 +61,7 @@ data "archive_file" "default" {
   output_path = "/tmp/function-source.zip"
 
   # Edit Me: Replace with a path to the customized "ingestion" function code
-  source_dir  = "function-source/"
+  source_dir = "function-source/"
 }
 
 # Create a bucket to store the Cloud Run Function code

--- a/gen-ai-rag-vertex-ai-vector-search/serving.tf
+++ b/gen-ai-rag-vertex-ai-vector-search/serving.tf
@@ -21,7 +21,7 @@ resource "google_cloud_run_v2_service" "serving" {
 
   template {
     containers {
-      # Note: Replace with the customized container image.
+      # Edit Me: Replace with the customized "frontend" container image.
       image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
   }
@@ -50,7 +50,7 @@ resource "google_cloud_run_v2_service" "backend" {
 
   template {
     containers {
-      # Note: Replace with the customized container image.
+      # Edit Me: Replace with the customized "backend" container image.
       image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
   }

--- a/gen-ai-rag-vertex-ai-vector-search/vertex.tf
+++ b/gen-ai-rag-vertex-ai-vector-search/vertex.tf
@@ -20,6 +20,9 @@ resource "google_vertex_ai_index" "default" {
 
     # Note: The index config should be customized based on your model.
     config {
+      # Note: Ensure this matches the dimensionality of your model.
+      # For example, text-embedding-005 uses 768-dimensional vectors
+      # https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings
       dimensions                  = 768
       approximate_neighbors_count = 0
       distance_measure_type       = "DOT_PRODUCT_DISTANCE"

--- a/gen-ai-rag-vertex-ai-vector-search/vertex.tf
+++ b/gen-ai-rag-vertex-ai-vector-search/vertex.tf
@@ -20,7 +20,7 @@ resource "google_vertex_ai_index" "default" {
 
     # Note: The index config should be customized based on your model.
     config {
-      dimensions                  = 1536
+      dimensions                  = 768
       approximate_neighbors_count = 0
       distance_measure_type       = "DOT_PRODUCT_DISTANCE"
       algorithm_config {


### PR DESCRIPTION
Not all reference samples will include example applications, but gen-ai-rag-vertex-ai-vector-search does. 

As such, this PR updates the _comments_ and README to support using a devrel-demos example application (no maintenance intended, different from a maintained _sample_ application). 

This also changes the comment schema to define two separate notes: 

 * Changes that must be made to have a functioning deployment ("Edit me"). 
 * Changes that should be customized in order to have a production-ready deployment ("Note")
   * This is on top of any called out Design Considerations already in place from the original reference. 

The author has not yet personally tried to use the TF code in conjunction with the example application, but some changes may need to be made to that code's READMEs to support a more streamlined deployment, but that level of detail is outside of the intended support of both repos. 