### PR TITLE
Add "Purpose" sections to Oracle EBS and PeopleSoft READMEs

### DIFF
--- a/oracle-ebs-framework/README-customer-data.md
+++ b/oracle-ebs-framework/README-customer-data.md
@@ -7,7 +7,7 @@ This repository provides Terraform configurations and Makefile automation to dep
 This artifact provides a fully automated framework to deploy a two-node **Oracle E-Business Suite (EBS) R12.2 Customer data** environment onto a clean Google Cloud Platform (GCP) project. Utilizing Terraform for infrastructure-as-code and automated staging/installation scripts, this toolkit eliminates the manual complexity typically associated with cloning Oracle EBS. 
 
 The primary goals of this repository are to:
-* **Accelerate Evaluation:** Allow enterprise architects, administrators, and business users to rapidly stand up an operational Oracle EBS with real data instance to evaluate its functionality, workflow engine, and user experience on GCP.
+* **Accelerate Evaluation:** Allow enterprise architects, administrators, and business users to rapidly stand up an operational Oracle EBS instance with real data to evaluate its functionality, workflow engine, and user experience on GCP.
 * **Benchmark Performance:** Provide an isolated sandbox environment to test, review, and baseline the performance capabilities of Oracle workloads running on Google Cloud Compute Engine and SSD Persistent Disks.
 * **Demonstrate Best Practices:** Serve as a reference implementation for cloud infrastructure layout, Identity-Aware Proxy (IAP) secure tunneling, and automated deployment patterns for legacy enterprise applications.
 

--- a/oracle-ebs-framework/README-customer-data.md
+++ b/oracle-ebs-framework/README-customer-data.md
@@ -2,6 +2,17 @@
 
 This repository provides Terraform configurations and Makefile automation to deploy Oracle EBS infrastructure on Google Cloud Platform.
 
+## Purpose
+
+This artifact provides a fully automated framework to deploy a two-node **Oracle E-Business Suite (EBS) R12.2 Customer data** environment onto a clean Google Cloud Platform (GCP) project. Utilizing Terraform for infrastructure-as-code and automated staging/installation scripts, this toolkit eliminates the manual complexity typically associated with cloning Oracle EBS. 
+
+The primary goals of this repository are to:
+* **Accelerate Evaluation:** Allow enterprise architects, administrators, and business users to rapidly stand up an operational Oracle EBS with real data instance to evaluate its functionality, workflow engine, and user experience on GCP.
+* **Benchmark Performance:** Provide an isolated sandbox environment to test, review, and baseline the performance capabilities of Oracle workloads running on Google Cloud Compute Engine and SSD Persistent Disks.
+* **Demonstrate Best Practices:** Serve as a reference implementation for cloud infrastructure layout, Identity-Aware Proxy (IAP) secure tunneling, and automated deployment patterns for legacy enterprise applications.
+
+*Note: This environment is intended for demonstration, testing, and proof-of-concept (PoC) purposes and is not intended for production workloads.*
+
 
 ## Folder Structure
 

--- a/oracle-ebs-framework/README-exascale-vision.md
+++ b/oracle-ebs-framework/README-exascale-vision.md
@@ -2,6 +2,16 @@
 
 This repository provides Terraform configurations and Makefile automation to deploy Oracle EBS Vision infrastructure on Google Cloud Platform and Oracle Database@Google Cloud .
 
+## Purpose
+
+This artifact provides a fully automated framework to deploy a single-node **Oracle E-Business Suite (EBS) R12.2 Vision on Exascale@GCP** environment onto a clean Google Cloud Platform (GCP) project. Utilizing Terraform for infrastructure-as-code and automated staging/installation scripts, this toolkit eliminates the manual complexity typically associated with provisioning Oracle EBS on Exascale@GCP. 
+
+The primary goals of this repository are to:
+* **Accelerate Evaluation:** Allow enterprise architects, administrators, and business users to rapidly stand up an operational Oracle EBS Vision instance on Exascale@GCP to evaluate its functionality, workflow engine, and user experience on GCP.
+* **Benchmark Performance:** Provide an isolated sandbox environment to test, review, and baseline the performance capabilities of Oracle workloads running on Google Cloud Compute Engine and SSD Persistent Disks.
+* **Demonstrate Best Practices:** Serve as a reference implementation for cloud infrastructure layout, Identity-Aware Proxy (IAP) secure tunneling, and automated deployment patterns for legacy enterprise applications.
+
+*Note: This environment is intended for demonstration, testing, and proof-of-concept (PoC) purposes and is not intended for production workloads.*
 
 ## Architectural Diagram
 

--- a/oracle-ebs-framework/README.md
+++ b/oracle-ebs-framework/README.md
@@ -5,6 +5,17 @@ This repository provides Terraform configurations and Makefile automation to dep
  - follow [README-exascale-vision.md](README-exascale-vision.md) to Setup Oracle **EBS R12.2 Vision** Environment on **Oracle ExaScale@GCP**
  - follow [README-customer-data.md](README-customer-data.md) to Setup Oracle **EBS R12.2** environment with customer data
 
+## Purpose
+
+This artifact provides a fully automated framework to deploy a single-node **Oracle E-Business Suite (EBS) R12.2 Vision** environment onto a clean Google Cloud Platform (GCP) project. Utilizing Terraform for infrastructure-as-code and automated staging/installation scripts, this toolkit eliminates the manual complexity typically associated with provisioning Oracle EBS.
+
+The primary goals of this repository are to:
+
+* **Accelerate Evaluation:** Allow enterprise architects, administrators, and business users to rapidly stand up an operational Oracle EBS Vision instance to evaluate its functionality, workflow engine, and user experience on GCP.
+* **Benchmark Performance:** Provide an isolated sandbox environment to test, review, and baseline the performance capabilities of Oracle workloads running on Google Cloud Compute Engine and SSD Persistent Disks.
+* **Demonstrate Best Practices:**  Serve as a reference implementation for cloud infrastructure layout, Identity-Aware Proxy (IAP) secure tunneling, and automated deployment patterns for legacy enterprise applications.
+
+*Note: This environment is intended for demonstration, testing, and proof-of-concept (PoC) purposes and is not intended for production workloads.*
 
 ## Architectural Diagram
 

--- a/oracle-peoplesoft-framework/README.md
+++ b/oracle-peoplesoft-framework/README.md
@@ -1,5 +1,18 @@
 # Oracle PeopleSoft Toolkit on GCP | Oracle Peoplesoft PUM (Demo data)
 
+# Oracle PeopleSoft Toolkit on GCP | Oracle Peoplesoft PUM (Demo data)
+
+## Purpose
+
+This artifact provides a fully automated framework to deploy a single-node **Oracle Peoplesoft (PUM) Demo** environment onto a clean Google Cloud Platform (GCP) project. Utilizing Terraform for infrastructure-as-code and automated staging/installation scripts, this toolkit eliminates the manual complexity typically associated with provisioning Oracle Peoplesoft. 
+
+The primary goals of this repository are to:
+* **Accelerate Evaluation:** Allow enterprise architects, administrators, and business users to rapidly stand up an operational Oracle Peoplesoft Demo instance to evaluate its functionality, workflow engine, and user experience on GCP.
+* **Benchmark Performance:** Provide an isolated sandbox environment to test, review, and baseline the performance capabilities of Oracle workloads running on Google Cloud Compute Engine and SSD Persistent Disks.
+* **Demonstrate Best Practices:** Serve as a reference implementation for cloud infrastructure layout, Identity-Aware Proxy (IAP) secure tunneling, and automated deployment patterns for legacy enterprise applications.
+
+*Note: This environment is intended for demonstration, testing, and proof-of-concept (PoC) purposes and is not intended for production workloads.*
+
 ## Architectural Diagram
 
 ### Oracle Peoplesoft on GCP
@@ -14,7 +27,6 @@ Before starting, ensure the following requirements are met:
 - GCP Project: A Google Cloud project must already exist for this deployment. Note the `PROJECT_ID`.
 - Make: Install the `make` tool (version >= 4.3 recommended).
 - GCLOUD CLI
-- OCI CLI
 
 ### Quota Requirements
 Before deploying Toolkit, verify that your GCP project has sufficient resource quotas in the target region.
@@ -28,8 +40,6 @@ Check your current quotas with:
 gcloud compute regions describe <REGION> --project=<PROJECT_ID> \
   --format="flattened(quotas[].metric,quotas[].limit,quotas[].usage)" | grep SSD
   ```
-
-If the Persistent Disk SSD quota is less than 1 TB, the deployment will fail.
 
 Action if insufficient:
 

--- a/oracle-peoplesoft-framework/README.md
+++ b/oracle-peoplesoft-framework/README.md
@@ -1,7 +1,5 @@
 # Oracle PeopleSoft Toolkit on GCP | Oracle Peoplesoft PUM (Demo data)
 
-# Oracle PeopleSoft Toolkit on GCP | Oracle Peoplesoft PUM (Demo data)
-
 ## Purpose
 
 This artifact provides a fully automated framework to deploy a single-node **Oracle Peoplesoft (PUM) Demo** environment onto a clean Google Cloud Platform (GCP) project. Utilizing Terraform for infrastructure-as-code and automated staging/installation scripts, this toolkit eliminates the manual complexity typically associated with provisioning Oracle Peoplesoft. 

--- a/oracle-peoplesoft-framework/scripts/peoplesoft/funct.sh
+++ b/oracle-peoplesoft-framework/scripts/peoplesoft/funct.sh
@@ -55,7 +55,7 @@ print_summary(){
 
           hosts file entry   : 127.0.0.1 $(hostname -f) $(hostname)
           IAP tunneling      : 
-          	gcloud compute ssh "${hostname}" --tunnel-through-iap --project $(gcloud config get-value project) -- -L 8000:localhost:8000
+          	gcloud compute ssh $(hostname) --tunnel-through-iap --project $(gcloud config get-value project) -- -L 8000:localhost:8000
          -----------------------------------------
     \033[0m"    
 }


### PR DESCRIPTION
This PR introduces clear "Purpose" sections across the documentation for both the Oracle EBS and Oracle PeopleSoft deployment frameworks on GCP. It also includes a minor syntax fix for an IAP tunneling script.

Specifically, this PR includes:

Documentation Updates: Added ## Purpose sections to the following README files to clarify the goals (Accelerate Evaluation, Benchmark Performance, Demonstrate Best Practices):

oracle-ebs-framework/README.md

oracle-ebs-framework/README-customer-data.md

oracle-ebs-framework/README-exascale-vision.md

oracle-peoplesoft-framework/README.md

Script Fix: Corrected a variable interpolation issue in the gcloud compute ssh command within oracle-peoplesoft-framework/scripts/peoplesoft/funct.sh

